### PR TITLE
feat: new crate scion-grpc with setup for sciond

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -101,6 +101,7 @@ jobs:
         if: github.ref != 'refs/heads/main'
         with:
           save-if: "false"
+      - run: sudo apt-get install protobuf-compiler
       - run: cargo install cargo-tarpaulin@0.26.1
 
       - name: Run tests and record coverage
@@ -143,6 +144,7 @@ jobs:
         if: github.ref != 'refs/heads/main'
         with:
           save-if: "false"
+      - run: sudo apt-get install protobuf-compiler
       - run: cargo install cargo-sort@1.0.9
       - name: Check formatting with rustfmt
         run: >
@@ -167,6 +169,7 @@ jobs:
         if: github.ref != 'refs/heads/main'
         with:
           save-if: "false"
+      - run: sudo apt-get install protobuf-compiler
       - name: Build Rust code
         run: cargo build --verbose
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@ resolver = "2"
 
 members = [
     "crates/scion",
+    "crates/scion-grpc",
 ]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,22 @@ workflow](./CONTRIBUTING.md).
 
 ## Prerequisites
 
+### Ubuntu
+
 ```sh
+# Install C/C++ compilers, protobuf, SQLite3, clang
+sudo apt install -y build-essential protobuf-compiler libsqlite3-dev llvm-dev libclang-dev clang
+# Install Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+### Mac
+
+```sh
+# Install Homebrew
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+# Install protobuf
+brew install protobuf
 # Install Rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```

--- a/crates/scion-grpc/Cargo.toml
+++ b/crates/scion-grpc/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "scion-grpc"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+prost = "0.12.1"
+prost-types = "0.12.1"
+tonic = "0.10.2"
+
+[build-dependencies]
+tonic-build = "0.10.2"

--- a/crates/scion-grpc/build.rs
+++ b/crates/scion-grpc/build.rs
@@ -1,0 +1,6 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::configure()
+        .build_server(false)
+        .compile(&["proto/daemon/v1/daemon.proto"], &["./"])?;
+    Ok(())
+}

--- a/crates/scion-grpc/proto/daemon/v1/daemon.proto
+++ b/crates/scion-grpc/proto/daemon/v1/daemon.proto
@@ -1,0 +1,268 @@
+// Copyright 2020 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+option go_package = "github.com/scionproto/scion/pkg/proto/daemon";
+
+package proto.daemon.v1;
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
+import "proto/drkey/v1/drkey.proto";
+
+service DaemonService {
+    // Return a set of paths to the requested destination.
+    rpc Paths(PathsRequest) returns (PathsResponse) {}
+    // Return information about an AS.
+    rpc AS(ASRequest) returns (ASResponse) {}
+    // Return the underlay addresses associated with
+    // the specified interfaces.
+    rpc Interfaces(InterfacesRequest) returns (InterfacesResponse) {}
+    // Return the underlay addresses associated with the
+    // specified services.
+    rpc Services(ServicesRequest) returns (ServicesResponse) {}
+    // Inform the SCION Daemon of a revocation.
+    rpc NotifyInterfaceDown(NotifyInterfaceDownRequest) returns (NotifyInterfaceDownResponse) {}
+    // DRKeyASHost returns a key that matches the request.
+    rpc DRKeyASHost (DRKeyASHostRequest) returns (DRKeyASHostResponse) {}
+    // DRKeyHostAS returns a key that matches the request.
+    rpc DRKeyHostAS (DRKeyHostASRequest) returns (DRKeyHostASResponse) {}
+    // DRKeyHostHost returns a key that matches the request.
+    rpc DRKeyHostHost (DRKeyHostHostRequest) returns (DRKeyHostHostResponse) {}
+}
+
+message PathsRequest {
+    // ISD-AS of the source of the path request.
+    uint64 source_isd_as = 1;
+    // ISD-AS of the destination of the path request.
+    uint64 destination_isd_as = 2;
+    // Choose to fetch fresh paths for this request instead
+    // of having the server reply from its cache.
+    bool refresh = 3;
+    // Request hidden paths instead of standard paths.
+    bool hidden = 4;
+}
+
+message PathsResponse {
+    // List of paths found by the daemon.
+    repeated Path paths = 1;
+}
+
+message Path {
+    // The raw data-plane path.
+    bytes raw = 1;
+    // Interface for exiting the local AS using this path.
+    Interface interface = 2;
+    // The list of interfaces the path is composed of.
+    repeated PathInterface interfaces = 3;
+    // The maximum transmission unit (MTU) on the path.
+    uint32 mtu = 4;
+    // The point in time when this path expires. In seconds since UNIX epoch.
+    google.protobuf.Timestamp expiration = 5;
+    // Latency lists the latencies between any two consecutive interfaces.
+    // Entry i describes the latency between interface i and i+1.
+    // Consequently, there are N-1 entries for N interfaces.
+    // A 0-value indicates that the AS did not announce a latency for this hop.
+    repeated google.protobuf.Duration latency = 6;
+    // Bandwidth lists the bandwidth between any two consecutive interfaces, in
+    // Kbit/s.
+    // Entry i describes the bandwidth between interfaces i and i+1.
+    // A 0-value indicates that the AS did not announce a bandwidth for this
+    // hop.
+    repeated uint64 bandwidth = 7;
+    // Geo lists the geographical position of the border routers along the
+    // path.
+    // Entry i describes the position of the router for interface i.
+    // A 0-value indicates that the AS did not announce a position for this
+    // router.
+    repeated GeoCoordinates geo = 8;
+    // LinkType contains the announced link type of inter-domain links.
+    // Entry i describes the link between interfaces 2*i and 2*i+1.
+    repeated LinkType link_type = 9;
+    // InternalHops lists the number of AS internal hops for the ASes on path.
+    // Entry i describes the hop between interfaces 2*i+1 and 2*i+2 in the same
+    // AS.
+    // Consequently, there are no entries for the first and last ASes, as these
+    // are not traversed completely by the path.
+    repeated uint32 internal_hops = 10;
+    // Notes contains the notes added by ASes on the path, in the order of
+    // occurrence.
+    // Entry i is the note of AS i on the path.
+    repeated string notes = 11;
+    // EpicAuths contains the EPIC authenticators used to calculate the PHVF and LHVF.
+    EpicAuths epic_auths = 12;
+}
+
+message EpicAuths {
+    // AuthPHVF is the authenticator use to calculate the PHVF.
+    bytes auth_phvf = 1;
+    // AuthLHVF is the authenticator use to calculate the LHVF.
+    bytes auth_lhvf = 2;
+}
+
+message PathInterface {
+    // ISD-AS the interface belongs to.
+    uint64 isd_as = 1;
+    // ID of the interface in the AS.
+    uint64 id = 2;
+}
+
+message GeoCoordinates {
+    // Latitude of the geographic coordinate, in the WGS 84 datum.
+    float latitude = 1;
+    // Longitude of the geographic coordinate, in the WGS 84 datum.
+    float longitude = 2;
+    // Civic address of the location.
+    string address = 3;
+}
+
+enum LinkType {
+    // Unspecified link type.
+    LINK_TYPE_UNSPECIFIED = 0;
+    // Direct physical connection.
+    LINK_TYPE_DIRECT = 1;
+    // Connection with local routing/switching.
+    LINK_TYPE_MULTI_HOP = 2;
+    // Connection overlaid over publicly routed Internet.
+    LINK_TYPE_OPEN_NET = 3;
+}
+
+message ASRequest {
+    // ISD-AS of the AS information is requested about. The 0 value
+    // can be used to discover the ISD-AS number of the local AS.
+    uint64 isd_as = 1;
+}
+
+message ASResponse {
+    // ISD-AS of the AS information was requested about.
+    uint64 isd_as = 1;
+    // Indicates whether the local AS is core.
+    bool core = 2;
+    // The maximum transmission unit (MTU) in the local AS.
+    uint32 mtu = 3;
+}
+
+message InterfacesRequest { }
+
+message InterfacesResponse {
+    // Map from SCION interface IDs in the local AS to interface details.
+    map<uint64, Interface> interfaces = 1;
+}
+
+message Interface {
+    // Underlay address to exit through the interface.
+    Underlay address = 1;
+}
+
+message ServicesRequest { }
+
+message ServicesResponse {
+    // Map from service names to known services.
+    map<string, ListService> services = 1;
+}
+
+message ListService {
+    // Services is the list of services.
+    repeated Service services = 1;
+}
+
+message Service {
+    // Address of the service instance, in RFC 3986 format.
+    string uri = 1;
+}
+
+// Address of an underlay socket.
+message Underlay {
+    // The underlay address in standard IP:port notation (e.g., 192.0.2.1:10000
+    // or [2001:db8::1]:10000). The underlay is UDP/IP.
+    string address = 1;
+}
+
+message NotifyInterfaceDownRequest {
+    // ISD-AS the failing interface belongs to.
+    uint64 isd_as = 1;
+    // ID of the failing interface.
+    uint64 id = 2;
+}
+
+message NotifyInterfaceDownResponse {};
+
+message DRKeyHostASRequest{
+    // Point in time where requested key is valid.
+    google.protobuf.Timestamp val_time = 1;
+    // Protocol value.
+    proto.drkey.v1.Protocol protocol_id = 2;
+    // Src ISD-AS of the requested DRKey.
+    uint64 src_ia = 3;
+    // Dst ISD-AS of the requested DRKey.
+    uint64 dst_ia = 4;
+    // Src Host of the request DRKey.
+    string src_host = 5;
+}
+
+message DRKeyHostASResponse{
+    // Begin of validity period of DRKey.
+    google.protobuf.Timestamp epoch_begin = 1;
+    // End of validity period of DRKey.
+    google.protobuf.Timestamp epoch_end = 2;
+    // Level2 key.
+    bytes key = 3;
+}
+
+message DRKeyASHostRequest{
+    // Point in time where requested key is valid.
+    google.protobuf.Timestamp val_time = 1;
+    // Protocol value.
+    proto.drkey.v1.Protocol protocol_id = 2;
+    // Src ISD-AS of the requested DRKey.
+    uint64 src_ia = 3;
+    // Dst ISD-AS of the requested DRKey.
+    uint64 dst_ia = 4;
+    // Dst Host of the request DRKey.
+    string dst_host = 5;
+}
+
+message DRKeyASHostResponse{
+    // Begin of validity period of DRKey.
+    google.protobuf.Timestamp epoch_begin = 1;
+    // End of validity period of DRKey.
+    google.protobuf.Timestamp epoch_end = 2;
+    // Level2 key.
+    bytes key = 3;
+}
+
+message DRKeyHostHostRequest{
+    // Point in time where requested key is valid.
+    google.protobuf.Timestamp val_time = 1;
+    // Protocol value.
+    proto.drkey.v1.Protocol protocol_id = 2;
+    // Src ISD-AS of the requested DRKey.
+    uint64 src_ia = 3;
+    // Dst ISD-AS of the requested DRKey.
+    uint64 dst_ia = 4;
+    // Src Host of the request DRKey.
+    string src_host = 5;
+    // Dst Host of the request DRKey.
+    string dst_host = 6;
+}
+
+message DRKeyHostHostResponse{
+    // Begin of validity period of DRKey.
+    google.protobuf.Timestamp epoch_begin = 1;
+    // End of validity period of DRKey.
+    google.protobuf.Timestamp epoch_end = 2;
+    // Level2 key.
+    bytes key = 3;
+}

--- a/crates/scion-grpc/proto/drkey/v1/drkey.proto
+++ b/crates/scion-grpc/proto/drkey/v1/drkey.proto
@@ -1,0 +1,27 @@
+// Copyright 2022 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+option go_package = "github.com/scionproto/scion/pkg/proto/drkey";
+
+package proto.drkey.v1;
+
+enum Protocol{
+    // Generic is used to derive keys in the generic derivation scheme
+    PROTOCOL_GENERIC_UNSPECIFIED = 0;
+    // SCMP protocol
+    PROTOCOL_SCMP = 1;
+    reserved 65536 to max; // only 16-bit values allowed
+}

--- a/crates/scion-grpc/src/lib.rs
+++ b/crates/scion-grpc/src/lib.rs
@@ -1,0 +1,23 @@
+//! `scion-grpc` provides bindings [gRPC](https://grpc.io/) types and services used within SCION's
+//! control plane.
+pub use prost::Message;
+
+pub mod drkey {
+    pub mod v1 {
+        tonic::include_proto!("proto.drkey.v1");
+    }
+}
+
+pub mod daemon {
+    //! Types and services for interacting with the SCION daemon (sciond).
+
+    pub mod v1 {
+        //! Version 1 sciond types and services.
+        //!
+        //! The primary entry point is the [daemon_service_client::DaemonServiceClient] that
+        //! enables an application to query its local sciond service.
+
+        tonic::include_proto!("proto.daemon.v1");
+    }
+    pub use v1::daemon_service_client::DaemonServiceClient;
+}

--- a/crates/scion/Cargo.toml
+++ b/crates/scion/Cargo.toml
@@ -3,7 +3,6 @@ name = "scion"
 version = "0.1.0"
 edition = "2021"
 publish = false
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 serde = { version = "1.0.188", features = ["derive"] }

--- a/deny.toml
+++ b/deny.toml
@@ -17,8 +17,9 @@ unlicensed = "deny"
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
-    "MIT",
     "Apache-2.0",
+    "BSD-3-Clause",
+    "MIT",
 ]
 # Lint level for licenses considered copyleft
 copyleft = "deny"
@@ -55,6 +56,16 @@ ignore = true
 [bans]
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "deny"
+skip = [
+    # indexmap v1.9.3 uses an old version
+    { name = "hashbrown", version = "=0.12.3" },
+    # h2 + tower use an old version
+    { name = "indexmap", version = "=1.9.3" },
+    # hyper uses an old version
+    { name = "socket2", version = "=0.4.9" },
+    # axum + redox_syscall use an old version
+    { name = "bitflags", version = "=1.3.2" },
+]
 
 # This section is considered when running `cargo deny check sources`.
 # More documentation about the 'sources' section can be found here:


### PR DESCRIPTION
This adds protobuf definitions and gRPC generation for the sciond communication. This is largely copied from https://github.com/MystenLabs/scion-hp-market/tree/main/crates/scion-grpc (partially from https://github.com/scionproto/scion, partially authored by @jpcsmith), but I left out all the other protobuf definitions as we probably won't need them.

The PR also updates other project setup as required by the protobuf addition.

Contributes to #12 