### PR TITLE
ci: add scheduled workflow to update pre-commit hooks

### DIFF
--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -1,0 +1,33 @@
+name: Updates
+
+on:
+  # every Sunday
+  schedule:
+    - cron: '14 3 * * 0'
+  # on demand
+  workflow_dispatch:
+
+jobs:
+  pre-commit:
+    name: "Update pre-commit hooks and run them on all files"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - run: rustup update stable
+      - run: cargo install cargo-sort@1.0.9
+      - run: pip install pre-commit
+      - run: pre-commit autoupdate
+      - run: pre-commit run --all-files
+      - uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/update-pre-commit-hooks
+          title: "chore: update pre-commit hooks"
+          commit-message: "chore: update pre-commit hooks"
+          body: Update pre-commit hooks to latest version.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,12 +23,12 @@ repos:
     - "--"
     - "--config"
     - "group_imports=StdExternalCrate,imports_granularity=Crate,imports_layout=HorizontalVertical"
-    language: system
+    language: rust
     types: [rust]
     pass_filenames: false
   - id: cargo-sort
     name: cargo-sort
-    entry: cargo sort
+    entry: cargo-sort
     args: ["-w"]
     language: rust
     types: [rust]
@@ -36,26 +36,26 @@ repos:
   - id: cargo-check
     name: cargo-check
     entry: cargo check
-    language: system
+    language: rust
     types: [rust]
     pass_filenames: false
   - id: cargo-test
     name: cargo-test
     entry: cargo test
-    language: system
+    language: rust
     types: [rust]
     pass_filenames: false
   - id: clippy
     name: clippy
     entry: cargo clippy
     args: ["--all-features", "--tests", "--", "-D", "warnings"]
-    language: system
+    language: rust
     types: [rust]
     pass_filenames: false
   - id: deny
     name: cargo-deny
     entry: cargo deny
     args: ["--all-features", "check"]
-    language: system
+    language: rust
     types: [rust]
     pass_filenames: false


### PR DESCRIPTION
As Dependabot doesn't update pre-commit hooks, the versions of those diverge with the versions used in CI. This adds a weekly workflow to automatically bump all pre-commit hooks to the latest version, runs them on the repository, and creates a pull request.

