### PR TITLE
refactor: unify dependencies among crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,13 @@ members = [
     "crates/scion-grpc",
     "crates/scion-proto",
 ]
+
+[workspace.dependencies]
+bytes = "1.5.0"
+prost = "0.12"
+prost-types = "0.12"
+scion-grpc = { version = "0.1.0", path = "crates/scion-grpc" }
+thiserror = "1.0.50"
+tonic = "0.10"
+tonic-build = "0.10"
+tracing = "0.1.40"

--- a/crates/scion-grpc/Cargo.toml
+++ b/crates/scion-grpc/Cargo.toml
@@ -6,9 +6,9 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-prost = "0.12.1"
-prost-types = "0.12.1"
-tonic = "0.10.2"
+prost = { workspace = true }
+prost-types = { workspace = true }
+tonic = { workspace = true }
 
 [build-dependencies]
-tonic-build = "0.10.2"
+tonic-build = { workspace = true }

--- a/crates/scion-proto/Cargo.toml
+++ b/crates/scion-proto/Cargo.toml
@@ -6,12 +6,12 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-bytes = "1.5.0"
+bytes = { workspace = true }
 chrono = { version = "0.4.31", default-features = false }
-scion-grpc = { version = "0.1.0", path = "../scion-grpc" }
+scion-grpc = { workspace = true }
 serde = { version = "1.0.188", features = ["derive"] }
-thiserror = "1.0.48"
-tracing = "0.1.40"
+thiserror = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-prost-types = "0.12.2"
+prost-types = { workspace = true }

--- a/crates/scion-proto/src/packet.rs
+++ b/crates/scion-proto/src/packet.rs
@@ -4,6 +4,7 @@
 //! format, and errors encountered while decoding the packet.
 //!
 //! For paths useable in a SCION packet, see the [path module][`crate::path`].
+
 use bytes::{Buf, Bytes};
 
 use crate::{

--- a/crates/scion/Cargo.toml
+++ b/crates/scion/Cargo.toml
@@ -6,13 +6,13 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-bytes = "1.5.0"
-scion-grpc = { version = "0.1.0", path = "../scion-grpc" }
+bytes = { workspace = true }
+scion-grpc = { workspace = true }
 scion-proto = { version = "0.1.0", path = "../scion-proto" }
-thiserror = "1.0.50"
+thiserror = { workspace = true }
 tokio = { version = "1.34.0", features = ["rt-multi-thread", "macros"] }
-tonic = "0.10.2"
-tracing = "0.1.40"
+tonic = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 tracing-subscriber = "0.3.17"

--- a/deny.toml
+++ b/deny.toml
@@ -66,6 +66,8 @@ skip = [
     # axum + redox_syscall use an old version
     { name = "bitflags", version = "=1.3.2" },
 ]
+# Several crates depend on an older version of windows-sys
+skip-tree = [{ name = "windows-sys", depth = 3, version = "0.48"}]
 
 # This section is considered when running `cargo deny check sources`.
 # More documentation about the 'sources' section can be found here:


### PR DESCRIPTION
An update to a few crates caused duplicate dependencies which were disallowed by cargo-deny.

This PR allows the windows-sys duplicate and also refactors our crates to share versions of packages.