### PR TITLE
refactor: use path buffer provided by caller in recv*_with_path

### DIFF
--- a/crates/scion-proto/src/path.rs
+++ b/crates/scion-proto/src/path.rs
@@ -28,9 +28,9 @@ pub use epic::EpicAuths;
 
 /// A SCION end-to-end path with optional metadata.
 #[derive(Debug, Clone, PartialEq)]
-pub struct Path {
+pub struct Path<T = Bytes> {
     /// The raw bytes to be added as the path header to SCION dataplane packets.
-    pub dataplane_path: DataplanePath,
+    pub dataplane_path: DataplanePath<T>,
     /// The underlay address (IP + port) of the next hop; i.e., the local border router.
     pub underlay_next_hop: Option<SocketAddr>,
     /// The ISD-ASN where the path starts and ends.
@@ -40,9 +40,9 @@ pub struct Path {
 }
 
 #[allow(missing_docs)]
-impl Path {
+impl<T> Path<T> {
     pub fn new(
-        dataplane_path: DataplanePath,
+        dataplane_path: DataplanePath<T>,
         isd_asn: ByEndpoint<IsdAsn>,
         underlay_next_hop: Option<SocketAddr>,
     ) -> Self {
@@ -76,7 +76,10 @@ impl Path {
     pub fn is_empty(&self) -> bool {
         self.dataplane_path.is_empty()
     }
+}
 
+#[allow(missing_docs)]
+impl Path<Bytes> {
     #[tracing::instrument]
     pub fn try_from_grpc_with_endpoints(
         mut value: daemon_grpc::Path,

--- a/crates/scion/tests/test_udp_socket.rs
+++ b/crates/scion/tests/test_udp_socket.rs
@@ -55,7 +55,7 @@ macro_rules! test_send_receive_reply {
                 let (socket_source, socket_destination, ..) = get_sockets().await?;
                 socket_source.send(MESSAGE.clone()).await?;
 
-                let mut buffer = [0_u8; 100];
+                let mut buffer = vec![0_u8; 1500];
                 let (length, sender) =
                     tokio::time::timeout(TIMEOUT, socket_destination.recv_from(&mut buffer))
                         .await??;
@@ -72,7 +72,7 @@ macro_rules! test_send_receive_reply {
                 let (socket_source, socket_destination, path_forward) = get_sockets().await?;
                 socket_source.send(MESSAGE.clone()).await?;
 
-                let mut buffer = [0_u8; 100];
+                let mut buffer = vec![0_u8; 1500];
                 let (length, sender, path) = tokio::time::timeout(
                     TIMEOUT,
                     socket_destination.recv_from_with_path(&mut buffer),


### PR DESCRIPTION
This commit modifies the path types to be generic over the underlying storage. This enables us to store paths in buffers provided by a caller as opposed to needing to allocate storage for paths.