### PR TITLE
chore: less strict pre-commit config for cargo-deny

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,6 +70,6 @@ repos:
     name: cargo-deny
     entry: cargo deny
     files: Cargo.(lock|toml)
-    args: ["--all-features", "check", "-D", "warnings"]
+    args: ["--all-features", "check"]
     language: rust
     pass_filenames: false


### PR DESCRIPTION
The strict configuration with `-D warnings` causes issues when running in different environments like CI (see, e.g., https://github.com/MystenLabs/scion-rs/actions/runs/7374581945/job/20065132777).