### PR TITLE
chore: pin Rust version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
               - 'crates/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
-              - 'rust-toolchain'
+              - 'rust-toolchain.toml'
               - '.github/workflows/rust.yml'
 
   dependencies:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.78"
 components = [ "clippy", "rustfmt" ]


### PR DESCRIPTION
This prevents unexpected errors/warnings due to new/updated lints.