### PR TITLE
fix: correct checksum for misaligned slices

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,6 +100,8 @@ jobs:
       - run: cargo install cargo-tarpaulin@0.27.1
       - name: Install SCION and run local topology
         uses: "./.github/actions/setup-scion"
+        with:
+          scion-ref: v0.11.0
         id: scion
 
       - name: Run tests (including integration tests) and record coverage

--- a/crates/scion-proto/src/packet/checksum.rs
+++ b/crates/scion-proto/src/packet/checksum.rs
@@ -265,6 +265,24 @@ mod tests {
         assert_eq!(checksum, !0xddf2);
     }
 
+    #[test]
+    fn rfc1071_example_slice_unaligned() {
+        // Construct a slice that is not 2B aligned.
+        let mut data = b"\0\0\x01\xf2\x03\xf4\xf5\xf6\xf7".to_vec();
+        let slice = if data.as_ptr().align_offset(2) == 0 {
+            &data[1..]
+        } else {
+            data.rotate_left(1);
+            &data[..data.len() - 1]
+        };
+
+        assert_eq!(slice.as_ptr().align_offset(2), 1);
+        assert_eq!(
+            ChecksumDigest::default().add_slice(slice).checksum(),
+            !0xddf2
+        );
+    }
+
     macro_rules! test_checksum {
         (
             name: $name:ident,

--- a/crates/scion-proto/src/path/standard.rs
+++ b/crates/scion-proto/src/path/standard.rs
@@ -126,9 +126,7 @@ where
     ///
     /// There are always at most 3 segments.
     pub fn segment(&self, segment_index: usize) -> Option<Segment> {
-        let Some(info_field) = self.info_field(segment_index) else {
-            return None;
-        };
+        let info_field = self.info_field(segment_index)?;
 
         // Get the index of the first hop field in the segment.
         // This is equivalent to the index after all preceding hop fields.

--- a/crates/scion/src/pan/path_strategy/refresher.rs
+++ b/crates/scion/src/pan/path_strategy/refresher.rs
@@ -341,9 +341,7 @@ impl<'a> Iterator for PathsTo<'a> {
     type Item = &'a Path;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let Some(paths) = self.paths else {
-            return None;
-        };
+        let paths = self.paths?;
 
         #[allow(clippy::while_let_on_iterator)]
         while let Some(info) = self.inner.next() {


### PR DESCRIPTION
Also fix some new linter complaints and pin the SCION reference to the last release with dispatcher (`v0.11.0`), see also #13.